### PR TITLE
fix: Fix changeset release workflow

### DIFF
--- a/.changeset/fix-version-script.md
+++ b/.changeset/fix-version-script.md
@@ -1,0 +1,10 @@
+---
+'@hugsylabs/hugsy': patch
+'@hugsylabs/hugsy-compiler': patch
+'@hugsylabs/hugsy-types': patch
+---
+
+fix: update version script to include lockfile-only install
+
+- Fix changeset workflow by updating package.json version script
+- Ensures pnpm install --lockfile-only runs after version bumping

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
           publish: pnpm publish:ci
           commit: 'chore: release packages'
           title: 'chore: release packages'
-          version: pnpm changeset version && pnpm install --lockfile-only
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:unit": "vitest run packages/",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,md,json,yml,yaml}\"",
     "changeset": "changeset",
-    "version": "changeset version",
+    "version": "changeset version && pnpm install --lockfile-only",
     "release": "turbo build && changeset publish",
     "publish:ci": "changeset publish"
   },


### PR DESCRIPTION
## Summary
  - Fix changeset version script to properly update lockfile after version bumping
  - This resolves the "No commits between main and changeset-release/main" error

  ## Problem
  The GitHub Action was failing because `changeset version` wasn't creating any changes. The root cause was that the `version` script in package.json was only running `changeset
  version` without updating the lockfile.

  ## Solution
  Update the `version` script in package.json to:
  ```json
  "version": "changeset version && pnpm install --lockfile-only"

  This ensures that after bumping versions, the lockfile is updated to reflect the new versions.

  Test plan

  - Changeset file included
  - Package.json version script updated
  - After merge, verify GitHub Action creates Version Packages PR successfully