### PR TITLE
fix: Fix changeset release workflow to auto-update lockfile

### DIFF
--- a/.changeset/fix-changeset-lockfile.md
+++ b/.changeset/fix-changeset-lockfile.md
@@ -1,0 +1,11 @@
+---
+'@hugsylabs/hugsy': patch
+'@hugsylabs/hugsy-compiler': patch
+'@hugsylabs/hugsy-types': patch
+---
+
+fix: Fix changeset release workflow to automatically update pnpm-lock.yaml
+
+- Add version:packages script that updates lockfile after version bumps
+- Ensure Version Packages PR includes updated lockfile
+- This fixes CI failures on changeset-created PRs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+          version: pnpm version:packages
           publish: pnpm publish:ci
           commit: 'chore: release packages'
           title: 'chore: release packages'

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "changeset": "changeset",
     "version": "changeset version && pnpm install --lockfile-only",
     "release": "turbo build && changeset publish",
-    "publish:ci": "changeset publish"
+    "publish:ci": "changeset publish",
+    "version:packages": "changeset version && pnpm install --lockfile-only"
   },
   "keywords": [
     "ai",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,10 +61,10 @@ importers:
   packages/cli:
     dependencies:
       '@hugsylabs/hugsy-compiler':
-        specifier: ^0.1.0
+        specifier: ^0.1.1
         version: link:../compiler
       '@hugsylabs/hugsy-types':
-        specifier: ^0.0.3
+        specifier: ^0.0.4
         version: link:../types
       chalk:
         specifier: ^5.3.0
@@ -92,7 +92,7 @@ importers:
   packages/compiler:
     dependencies:
       '@hugsylabs/hugsy-types':
-        specifier: ^0.0.3
+        specifier: ^0.0.4
         version: link:../types
       '@types/glob':
         specifier: ^9.0.0


### PR DESCRIPTION
- Add version:packages script that runs pnpm install --lockfile-only
- Configure changeset to use this script for version updates
- This ensures Version Packages PR includes updated pnpm-lock.yaml
- Fixes CI failures due to lockfile mismatch