### PR TITLE
feat: add package management capabilities to Hugsy CLI

### DIFF
--- a/.changeset/add-package-management.md
+++ b/.changeset/add-package-management.md
@@ -1,0 +1,13 @@
+---
+"@hugsylabs/hugsy": minor
+---
+
+添加包管理功能
+
+- `hugsy init` 现在会自动运行 `install`（除非使用 `--no-install` 标志）
+- `hugsy install` 支持安装包：`hugsy install @hugsy-plugins/xxx` 
+- `hugsy uninstall` 支持双重功能：
+  - 不带参数：卸载整个 Hugsy
+  - 带参数：从配置中移除指定的包
+- 添加智能包类型检测（插件 vs 预设）
+- 支持 `--plugin` 和 `--preset` 标志来明确指定包类型

--- a/README.md
+++ b/README.md
@@ -115,29 +115,138 @@ npm install --save-dev @hugsylabs/hugsy
 hugsy init
 ```
 
-Choose a preset that matches your project type.
+Choose a preset that matches your project type. The configuration will be automatically installed.
 
-### 2. Customize your configuration
+> **Note:** Use `hugsy init --no-install` if you want to review the configuration before installing.
 
-Edit `.hugsyrc.json`:
+### 2. Install packages (optional)
 
-```json
-{
-  "extends": "@hugsylabs/hugsy-compiler/presets/development",
-  "slashCommands": {
-    "custom": "./.claude/commands/**/*.md"
-  }
-}
-```
-
-### 3. Compile and deploy
+Add plugins or presets to enhance your configuration:
 
 ```bash
-hugsy install
-# This generates .claude/settings.json and copies slash commands to .claude/commands/
+# Install a community plugin (example)
+hugsy install ./plugins/my-team-plugin.js
+
+# Install from npm (when available)
+hugsy install @hugsy/plugin-security
+
+# Install multiple packages
+hugsy install ./plugins/lint.js ./presets/team-config.json
+```
+
+### 3. Manage your configuration
+
+```bash
+# Check current status
+hugsy status
+
+# Uninstall specific packages
+hugsy uninstall ./plugins/my-team-plugin.js
+
+# Uninstall Hugsy completely
+hugsy uninstall
 ```
 
 Your Claude Code configuration is now ready!
+
+## CLI Reference
+
+### `hugsy init [preset]`
+
+Initialize Hugsy configuration in your project.
+
+**Arguments:**
+- `preset` - Optional preset to use (recommended, security, permissive, custom)
+
+**Options:**
+- `-f, --force` - Overwrite existing configuration
+- `--no-install` - Skip automatic installation after initialization
+
+**Example:**
+```bash
+# Interactive initialization
+hugsy init
+
+# Use specific preset
+hugsy init recommended
+
+# Initialize without auto-install
+hugsy init --no-install
+```
+
+### `hugsy install [packages...]`
+
+Install Hugsy configuration or add packages to your configuration.
+
+**Arguments:**
+- `packages` - Optional packages to install (plugins or presets)
+
+**Options:**
+- `-f, --force` - Overwrite existing configuration
+- `-v, --verbose` - Show detailed compilation process
+- `--no-backup` - Skip backup of existing settings
+- `--plugin` - Treat packages as plugins
+- `--preset` - Treat packages as presets
+
+**Example:**
+```bash
+# Install current configuration
+hugsy install
+
+# Install plugins
+hugsy install ./plugins/security.js ./plugins/lint.js
+
+# Install preset with explicit type
+hugsy install ./presets/strict-config.json --preset
+```
+
+### `hugsy uninstall [packages...]`
+
+Remove Hugsy or packages from your project.
+
+**Arguments:**
+- `packages` - Optional packages to uninstall (if not provided, uninstalls Hugsy entirely)
+
+**Options:**
+- `--keep-config` - Keep .hugsyrc.json file (for full uninstall)
+- `-y, --yes` - Skip confirmation
+
+**Example:**
+```bash
+# Uninstall specific packages
+hugsy uninstall ./plugins/security.js
+
+# Uninstall Hugsy completely
+hugsy uninstall
+
+# Uninstall without confirmation
+hugsy uninstall --yes
+```
+
+### `hugsy status`
+
+Check the current Hugsy installation status.
+
+**Example:**
+```bash
+hugsy status
+```
+
+### `hugsy config`
+
+Display the current Hugsy configuration.
+
+**Options:**
+- `-r, --raw` - Show raw configuration before compilation
+
+**Example:**
+```bash
+# Show compiled configuration
+hugsy config
+
+# Show raw .hugsyrc.json content
+hugsy config --raw
+```
 
 ## Plugin Development
 

--- a/packages/cli/src/utils/package-manager.ts
+++ b/packages/cli/src/utils/package-manager.ts
@@ -1,0 +1,215 @@
+/**
+ * Package manager utilities for installing and managing Hugsy plugins/presets
+ */
+
+import { execSync } from 'child_process';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { logger } from './logger.js';
+
+/**
+ * Detect which package manager is being used in the project
+ */
+export function detectPackageManager(): 'npm' | 'yarn' | 'pnpm' {
+  const cwd = process.cwd();
+  
+  // Check for lock files
+  if (existsSync(join(cwd, 'pnpm-lock.yaml'))) {
+    return 'pnpm';
+  }
+  if (existsSync(join(cwd, 'yarn.lock'))) {
+    return 'yarn';
+  }
+  // Default to npm
+  return 'npm';
+}
+
+/**
+ * Detect if a package name is a plugin or preset
+ */
+export function detectPackageType(packageName: string, options?: { plugin?: boolean; preset?: boolean }): 'plugin' | 'preset' {
+  // Explicit type from options
+  if (options?.plugin) return 'plugin';
+  if (options?.preset) return 'preset';
+  
+  // Check if it's a local file
+  if (packageName.startsWith('./') || packageName.startsWith('../') || packageName.startsWith('/')) {
+    // Local files: check extension
+    if (packageName.endsWith('.json')) return 'preset';
+    if (packageName.endsWith('.js') || packageName.endsWith('.mjs') || packageName.endsWith('.ts')) return 'plugin';
+  }
+  
+  // NPM packages: check naming convention
+  const lowerName = packageName.toLowerCase();
+  if (lowerName.includes('preset') || lowerName.includes('config')) {
+    return 'preset';
+  }
+  if (lowerName.includes('plugin')) {
+    return 'plugin';
+  }
+  
+  // Default to plugin
+  return 'plugin';
+}
+
+/**
+ * Install npm package using detected package manager
+ */
+export function installNpmPackage(packageName: string): boolean {
+  // Skip if it's a local file
+  if (packageName.startsWith('./') || packageName.startsWith('../') || packageName.startsWith('/')) {
+    return true;
+  }
+  
+  const pm = detectPackageManager();
+  const installCmd = {
+    npm: 'npm install --save-dev',
+    yarn: 'yarn add --dev',
+    pnpm: 'pnpm add -D'
+  }[pm];
+  
+  try {
+    logger.info(`📦 Installing ${packageName} using ${pm}...`);
+    execSync(`${installCmd} ${packageName}`, {
+      stdio: 'inherit',
+      cwd: process.cwd()
+    });
+    logger.success(`Package installed: ${packageName}`);
+    return true;
+  } catch (error) {
+    logger.error(`Failed to install package: ${packageName}`);
+    if (error instanceof Error) {
+      logger.error(error.message);
+    }
+    return false;
+  }
+}
+
+/**
+ * Update .hugsyrc.json with new package
+ */
+export function updateHugsyConfig(packageName: string, type: 'plugin' | 'preset'): boolean {
+  const configPath = join(process.cwd(), '.hugsyrc.json');
+  
+  if (!existsSync(configPath)) {
+    logger.error('No .hugsyrc.json found. Run "hugsy init" first.');
+    return false;
+  }
+  
+  try {
+    const configContent = readFileSync(configPath, 'utf8');
+    const config = JSON.parse(configContent);
+    
+    if (type === 'plugin') {
+      // Initialize plugins array if it doesn't exist
+      config.plugins ??= [];
+      
+      // Check if already exists
+      if (config.plugins.includes(packageName)) {
+        logger.warning(`Plugin ${packageName} already in configuration`);
+        return true;
+      }
+      
+      // Add to plugins array
+      config.plugins.push(packageName);
+      logger.success(`Added plugin to configuration: ${packageName}`);
+      
+    } else {
+      // Handle presets (extends field)
+      config.extends ??= [];
+      
+      // Normalize to array
+      if (typeof config.extends === 'string') {
+        config.extends = [config.extends];
+      }
+      
+      // Check if already exists
+      if (config.extends.includes(packageName)) {
+        logger.warning(`Preset ${packageName} already in configuration`);
+        return true;
+      }
+      
+      // Add to extends array
+      config.extends.push(packageName);
+      logger.success(`Added preset to configuration: ${packageName}`);
+    }
+    
+    // Write back to file
+    writeFileSync(configPath, JSON.stringify(config, null, 2));
+    return true;
+    
+  } catch (error) {
+    logger.error(`Failed to update .hugsyrc.json: ${String(error)}`);
+    return false;
+  }
+}
+
+/**
+ * Remove package from .hugsyrc.json
+ */
+export function removeFromHugsyConfig(packageName: string): boolean {
+  const configPath = join(process.cwd(), '.hugsyrc.json');
+  
+  if (!existsSync(configPath)) {
+    logger.error('No .hugsyrc.json found.');
+    return false;
+  }
+  
+  try {
+    const configContent = readFileSync(configPath, 'utf8');
+    const config = JSON.parse(configContent);
+    let removed = false;
+    
+    // Try to remove from plugins
+    if (config.plugins && Array.isArray(config.plugins)) {
+      const index = config.plugins.indexOf(packageName);
+      if (index > -1) {
+        config.plugins.splice(index, 1);
+        logger.success(`Removed plugin from configuration: ${packageName}`);
+        removed = true;
+        
+        // Clean up empty array
+        if (config.plugins.length === 0) {
+          delete config.plugins;
+        }
+      }
+    }
+    
+    // Try to remove from extends
+    if (config.extends) {
+      if (Array.isArray(config.extends)) {
+        const index = config.extends.indexOf(packageName);
+        if (index > -1) {
+          config.extends.splice(index, 1);
+          logger.success(`Removed preset from configuration: ${packageName}`);
+          removed = true;
+          
+          // Clean up empty array
+          if (config.extends.length === 0) {
+            delete config.extends;
+          } else if (config.extends.length === 1) {
+            // Convert back to string if only one item
+            config.extends = config.extends[0];
+          }
+        }
+      } else if (config.extends === packageName) {
+        delete config.extends;
+        logger.success(`Removed preset from configuration: ${packageName}`);
+        removed = true;
+      }
+    }
+    
+    if (!removed) {
+      logger.warning(`Package ${packageName} not found in configuration`);
+      return false;
+    }
+    
+    // Write back to file
+    writeFileSync(configPath, JSON.stringify(config, null, 2));
+    return true;
+    
+  } catch (error) {
+    logger.error(`Failed to update .hugsyrc.json: ${String(error)}`);
+    return false;
+  }
+}

--- a/packages/cli/tests/package-manager.test.ts
+++ b/packages/cli/tests/package-manager.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for package manager utilities
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { 
+  detectPackageType, 
+  detectPackageManager,
+  updateHugsyConfig,
+  removeFromHugsyConfig
+} from '../src/utils/package-manager';
+
+describe('Package Manager Utilities', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    // Create a temporary test directory
+    testDir = join(tmpdir(), `hugsy-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+    process.chdir(testDir);
+  });
+
+  afterEach(() => {
+    // Clean up
+    process.chdir('/');
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('detectPackageType', () => {
+    it('should detect plugin from package name', () => {
+      expect(detectPackageType('@hugsy-plugins/auth')).toBe('plugin');
+      expect(detectPackageType('my-plugin')).toBe('plugin');
+      expect(detectPackageType('@company/security-plugin')).toBe('plugin');
+    });
+
+    it('should detect preset from package name', () => {
+      expect(detectPackageType('@hugsy-presets/enterprise')).toBe('preset');
+      expect(detectPackageType('my-preset')).toBe('preset');
+      expect(detectPackageType('@company/team-config')).toBe('preset');
+    });
+
+    it('should detect type from file extension', () => {
+      expect(detectPackageType('./config.json')).toBe('preset');
+      expect(detectPackageType('../presets/base.json')).toBe('preset');
+      expect(detectPackageType('./plugin.js')).toBe('plugin');
+      expect(detectPackageType('./plugin.mjs')).toBe('plugin');
+      expect(detectPackageType('/absolute/path/plugin.ts')).toBe('plugin');
+    });
+
+    it('should respect explicit type options', () => {
+      expect(detectPackageType('ambiguous-name', { plugin: true })).toBe('plugin');
+      expect(detectPackageType('ambiguous-name', { preset: true })).toBe('preset');
+    });
+
+    it('should default to plugin for ambiguous names', () => {
+      expect(detectPackageType('some-package')).toBe('plugin');
+      expect(detectPackageType('@org/package')).toBe('plugin');
+    });
+  });
+
+  describe('detectPackageManager', () => {
+    it('should detect pnpm from lock file', () => {
+      writeFileSync(join(testDir, 'pnpm-lock.yaml'), '');
+      expect(detectPackageManager()).toBe('pnpm');
+    });
+
+    it('should detect yarn from lock file', () => {
+      writeFileSync(join(testDir, 'yarn.lock'), '');
+      expect(detectPackageManager()).toBe('yarn');
+    });
+
+    it('should default to npm when no lock file exists', () => {
+      expect(detectPackageManager()).toBe('npm');
+    });
+
+    it('should prefer pnpm over yarn', () => {
+      writeFileSync(join(testDir, 'pnpm-lock.yaml'), '');
+      writeFileSync(join(testDir, 'yarn.lock'), '');
+      expect(detectPackageManager()).toBe('pnpm');
+    });
+  });
+
+  describe('updateHugsyConfig', () => {
+    beforeEach(() => {
+      // Create a basic .hugsyrc.json
+      const config = {
+        env: { NODE_ENV: 'development' }
+      };
+      writeFileSync(join(testDir, '.hugsyrc.json'), JSON.stringify(config, null, 2));
+    });
+
+    it('should add plugin to configuration', () => {
+      const result = updateHugsyConfig('@hugsy-plugins/auth', 'plugin');
+      expect(result).toBe(true);
+
+      const config = JSON.parse(readFileSync(join(testDir, '.hugsyrc.json'), 'utf8'));
+      expect(config.plugins).toEqual(['@hugsy-plugins/auth']);
+    });
+
+    it('should add preset to configuration', () => {
+      const result =  updateHugsyConfig('@hugsy-presets/enterprise', 'preset');
+      expect(result).toBe(true);
+
+      const config = JSON.parse(readFileSync(join(testDir, '.hugsyrc.json'), 'utf8'));
+      expect(config.extends).toEqual(['@hugsy-presets/enterprise']);
+    });
+
+    it('should not duplicate plugins', () => {
+       updateHugsyConfig('@hugsy-plugins/auth', 'plugin');
+       updateHugsyConfig('@hugsy-plugins/auth', 'plugin');
+
+      const config = JSON.parse(readFileSync(join(testDir, '.hugsyrc.json'), 'utf8'));
+      expect(config.plugins).toEqual(['@hugsy-plugins/auth']);
+    });
+
+    it('should not duplicate presets', () => {
+       updateHugsyConfig('@hugsy-presets/enterprise', 'preset');
+       updateHugsyConfig('@hugsy-presets/enterprise', 'preset');
+
+      const config = JSON.parse(readFileSync(join(testDir, '.hugsyrc.json'), 'utf8'));
+      expect(config.extends).toEqual(['@hugsy-presets/enterprise']);
+    });
+
+    it('should convert string extends to array when adding preset', () => {
+      const config = {
+        extends: '@hugsy/recommended'
+      };
+      writeFileSync(join(testDir, '.hugsyrc.json'), JSON.stringify(config, null, 2));
+
+       updateHugsyConfig('@hugsy-presets/enterprise', 'preset');
+
+      const updatedConfig = JSON.parse(readFileSync(join(testDir, '.hugsyrc.json'), 'utf8'));
+      expect(updatedConfig.extends).toEqual(['@hugsy/recommended', '@hugsy-presets/enterprise']);
+    });
+
+    it('should return false if config does not exist', () => {
+      rmSync(join(testDir, '.hugsyrc.json'));
+      const result =  updateHugsyConfig('@hugsy-plugins/auth', 'plugin');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('removeFromHugsyConfig', () => {
+    beforeEach(() => {
+      // Create a config with plugins and presets
+      const config = {
+        env: { NODE_ENV: 'development' },
+        plugins: ['@hugsy-plugins/auth', '@hugsy-plugins/security'],
+        extends: ['@hugsy-presets/base', '@hugsy-presets/enterprise']
+      };
+      writeFileSync(join(testDir, '.hugsyrc.json'), JSON.stringify(config, null, 2));
+    });
+
+    it('should remove plugin from configuration', () => {
+      const result =  removeFromHugsyConfig('@hugsy-plugins/auth');
+      expect(result).toBe(true);
+
+      const config = JSON.parse(readFileSync(join(testDir, '.hugsyrc.json'), 'utf8'));
+      expect(config.plugins).toEqual(['@hugsy-plugins/security']);
+    });
+
+    it('should remove preset from configuration', () => {
+      const result =  removeFromHugsyConfig('@hugsy-presets/enterprise');
+      expect(result).toBe(true);
+
+      const config = JSON.parse(readFileSync(join(testDir, '.hugsyrc.json'), 'utf8'));
+      // When only one preset remains, it's converted to a string
+      expect(config.extends).toBe('@hugsy-presets/base');
+    });
+
+    it('should remove plugins field when empty', () => {
+       removeFromHugsyConfig('@hugsy-plugins/auth');
+       removeFromHugsyConfig('@hugsy-plugins/security');
+
+      const config = JSON.parse(readFileSync(join(testDir, '.hugsyrc.json'), 'utf8'));
+      expect(config.plugins).toBeUndefined();
+    });
+
+    it('should convert extends array to string when only one item remains', () => {
+       removeFromHugsyConfig('@hugsy-presets/enterprise');
+
+      const config = JSON.parse(readFileSync(join(testDir, '.hugsyrc.json'), 'utf8'));
+      expect(config.extends).toBe('@hugsy-presets/base');
+    });
+
+    it('should handle string extends field', () => {
+      const config = {
+        extends: '@hugsy-presets/base'
+      };
+      writeFileSync(join(testDir, '.hugsyrc.json'), JSON.stringify(config, null, 2));
+
+      const result =  removeFromHugsyConfig('@hugsy-presets/base');
+      expect(result).toBe(true);
+
+      const updatedConfig = JSON.parse(readFileSync(join(testDir, '.hugsyrc.json'), 'utf8'));
+      expect(updatedConfig.extends).toBeUndefined();
+    });
+
+    it('should return false if package not found', () => {
+      const result =  removeFromHugsyConfig('@hugsy-plugins/non-existent');
+      expect(result).toBe(false);
+    });
+
+    it('should return false if config does not exist', () => {
+      rmSync(join(testDir, '.hugsyrc.json'));
+      const result =  removeFromHugsyConfig('@hugsy-plugins/auth');
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/tests/package-management.test.ts
+++ b/tests/package-management.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Integration tests for package management features
+ */
+
+import { describe, it, beforeAll, afterAll, expect } from 'vitest';
+import { spawn } from 'child_process';
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const CLI_PATH = join(__dirname, '../packages/cli/dist/index.js');
+const TEST_DIR = '/tmp/hugsy-package-test-' + Date.now();
+
+interface TestResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+function runCommand(command: string, args: string[] = []): Promise<TestResult> {
+  return new Promise<TestResult>((resolve) => {
+    const proc = spawn('node', [CLI_PATH, command, ...args], {
+      cwd: TEST_DIR,
+      env: { ...process.env, NODE_ENV: 'test', NO_COLOR: '1' },
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (data) => (stdout += data.toString()));
+    proc.stderr.on('data', (data) => (stderr += data.toString()));
+
+    proc.on('close', (code: number | null) => {
+      resolve({ code: code || 0, stdout, stderr });
+    });
+  });
+}
+
+describe('Package Management Integration Tests', () => {
+  beforeAll(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterAll(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  describe('init with automatic installation', () => {
+    it('should initialize and install configuration automatically', async () => {
+      const result = await runCommand('init', ['recommended']);
+      
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('Created .hugsyrc.json');
+      expect(result.stdout).toContain('Created .claude directory');
+      expect(result.stdout).toContain('Created .claude/settings.json');
+      expect(result.stdout).toContain('Hugsy initialized and installed successfully!');
+      
+      // Verify files were created
+      expect(existsSync(join(TEST_DIR, '.hugsyrc.json'))).toBe(true);
+      expect(existsSync(join(TEST_DIR, '.claude/settings.json'))).toBe(true);
+    });
+
+    it('should skip installation with --no-install flag', async () => {
+      // Clean up first
+      rmSync(join(TEST_DIR, '.hugsyrc.json'), { force: true });
+      rmSync(join(TEST_DIR, '.claude'), { recursive: true, force: true });
+      
+      const result = await runCommand('init', ['recommended', '--no-install']);
+      
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('Created .hugsyrc.json');
+      expect(result.stdout).not.toContain('Created .claude directory');
+      expect(result.stdout).toContain('Run hugsy install to compile and activate');
+      
+      // Verify only config was created
+      expect(existsSync(join(TEST_DIR, '.hugsyrc.json'))).toBe(true);
+      expect(existsSync(join(TEST_DIR, '.claude/settings.json'))).toBe(false);
+    });
+  });
+
+  describe('install packages', () => {
+    beforeAll(async () => {
+      // Ensure we have a fresh config
+      rmSync(join(TEST_DIR, '.hugsyrc.json'), { force: true });
+      rmSync(join(TEST_DIR, '.claude'), { recursive: true, force: true });
+      await runCommand('init', ['recommended']);
+    });
+
+    it('should add local plugin to configuration', async () => {
+      // Create a test plugin
+      const pluginPath = join(TEST_DIR, 'test-plugin.mjs');
+      const pluginContent = `
+export default {
+  name: 'test-plugin',
+  transform(config) {
+    config.env = config.env || {};
+    config.env.TEST_PLUGIN = 'loaded';
+    return config;
+  }
+}`;
+      writeFileSync(pluginPath, pluginContent);
+      
+      const result = await runCommand('install', ['./test-plugin.mjs', '--force']);
+      
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('Processing ./test-plugin.mjs as plugin');
+      expect(result.stdout).toContain('Added plugin to configuration');
+      
+      // Verify config was updated
+      const config = JSON.parse(readFileSync(join(TEST_DIR, '.hugsyrc.json'), 'utf8'));
+      expect(config.plugins).toContain('./test-plugin.mjs');
+    });
+
+    it('should add local preset to configuration', async () => {
+      // Create a test preset
+      const presetPath = join(TEST_DIR, 'test-preset.json');
+      const presetContent = JSON.stringify({
+        env: {
+          PRESET_VAR: 'from_preset'
+        },
+        permissions: {
+          allow: ['Read(**/*.md)']
+        }
+      }, null, 2);
+      writeFileSync(presetPath, presetContent);
+      
+      const result = await runCommand('install', ['./test-preset.json', '--force']);
+      
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('Processing ./test-preset.json as preset');
+      expect(result.stdout).toContain('Added preset to configuration');
+      
+      // Verify config was updated
+      const config = JSON.parse(readFileSync(join(TEST_DIR, '.hugsyrc.json'), 'utf8'));
+      expect(Array.isArray(config.extends) ? config.extends : [config.extends])
+        .toContain('./test-preset.json');
+    });
+
+    it('should handle multiple packages in one command', async () => {
+      // Create another plugin
+      const plugin2Path = join(TEST_DIR, 'another-plugin.mjs');
+      const plugin2Content = `
+export default {
+  name: 'another-plugin',
+  transform(config) {
+    return config;
+  }
+}`;
+      writeFileSync(plugin2Path, plugin2Content);
+      
+      const result = await runCommand('install', [
+        './another-plugin.mjs',
+        '--force'
+      ]);
+      
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('Processing ./another-plugin.mjs as plugin');
+      
+      const config = JSON.parse(readFileSync(join(TEST_DIR, '.hugsyrc.json'), 'utf8'));
+      expect(config.plugins).toContain('./another-plugin.mjs');
+    });
+
+    it('should detect duplicate packages', async () => {
+      const result = await runCommand('install', ['./test-plugin.mjs', '--force']);
+      
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('already in configuration');
+    });
+  });
+
+  describe('uninstall packages', () => {
+    it('should remove plugin from configuration', async () => {
+      const result = await runCommand('uninstall', ['./test-plugin.mjs']);
+      
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('Removing ./test-plugin.mjs from configuration');
+      expect(result.stdout).toContain('Removed plugin from configuration');
+      
+      // Verify config was updated
+      const config = JSON.parse(readFileSync(join(TEST_DIR, '.hugsyrc.json'), 'utf8'));
+      expect(config.plugins).not.toContain('./test-plugin.mjs');
+    });
+
+    it('should remove preset from configuration', async () => {
+      const result = await runCommand('uninstall', ['./test-preset.json']);
+      
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('Removing ./test-preset.json from configuration');
+      expect(result.stdout).toContain('Removed preset from configuration');
+      
+      // Verify config was updated
+      const config = JSON.parse(readFileSync(join(TEST_DIR, '.hugsyrc.json'), 'utf8'));
+      const extends_ = Array.isArray(config.extends) ? config.extends : [config.extends];
+      expect(extends_).not.toContain('./test-preset.json');
+    });
+
+    it('should handle non-existent packages gracefully', async () => {
+      const result = await runCommand('uninstall', ['./non-existent.js']);
+      
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('not found in configuration');
+    });
+
+    it('should uninstall multiple packages', async () => {
+      // First add them back
+      await runCommand('install', ['./test-plugin.mjs', './another-plugin.mjs', '--force']);
+      
+      const result = await runCommand('uninstall', ['./test-plugin.mjs', './another-plugin.mjs']);
+      
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('Configuration updated successfully');
+      
+      const config = JSON.parse(readFileSync(join(TEST_DIR, '.hugsyrc.json'), 'utf8'));
+      expect(config.plugins || []).not.toContain('./test-plugin.mjs');
+      expect(config.plugins || []).not.toContain('./another-plugin.mjs');
+    });
+  });
+
+  describe('uninstall hugsy entirely', () => {
+    it('should uninstall hugsy when no packages provided', async () => {
+      const result = await runCommand('uninstall', ['--yes']);
+      
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('Uninstalling Hugsy');
+      expect(result.stdout).toContain('Removed .hugsyrc.json');
+      
+      // Verify config was removed
+      expect(existsSync(join(TEST_DIR, '.hugsyrc.json'))).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
- init command now automatically runs install (skip with --no-install)
- install command extended to support package installation
- uninstall command now dual-purpose: uninstall Hugsy or specific packages
- add smart package type detection (plugin vs preset)
- add comprehensive unit and integration tests
- update README with new CLI commands documentation

🤖 Generated with [Claude Code](https://claude.ai/code)