### PR TITLE
fix: add monorepo support for hugsy install command

### DIFF
--- a/.changeset/fix-monorepo-support.md
+++ b/.changeset/fix-monorepo-support.md
@@ -1,0 +1,9 @@
+---
+"@hugsylabs/hugsy": patch
+---
+
+Fix monorepo support for `hugsy install` command
+
+- Automatically detect pnpm workspace and add `-w` flag when installing packages
+- This fixes the issue where `hugsy install` would fail in monorepo projects with pnpm
+- No longer requires users to configure `.npmrc` with `ignore-workspace-root-check=true`

--- a/packages/cli/src/utils/package-manager.ts
+++ b/packages/cli/src/utils/package-manager.ts
@@ -62,17 +62,24 @@ export function installNpmPackage(packageName: string): boolean {
   }
   
   const pm = detectPackageManager();
-  const installCmd = {
+  const cwd = process.cwd();
+  let installCmd = {
     npm: 'npm install --save-dev',
     yarn: 'yarn add --dev',
     pnpm: 'pnpm add -D'
   }[pm];
   
+  // Check if we're in a pnpm workspace and adjust command accordingly
+  if (pm === 'pnpm' && existsSync(join(cwd, 'pnpm-workspace.yaml'))) {
+    installCmd = 'pnpm add -wD'; // Add -w flag for workspace root
+    logger.info('Detected pnpm workspace, using -w flag');
+  }
+  
   try {
     logger.info(`📦 Installing ${packageName} using ${pm}...`);
     execSync(`${installCmd} ${packageName}`, {
       stdio: 'inherit',
-      cwd: process.cwd()
+      cwd: cwd
     });
     logger.success(`Package installed: ${packageName}`);
     return true;


### PR DESCRIPTION
- Detect pnpm workspace and automatically add -w flag
- Fixes installation failures in monorepo projects
- No longer requires manual .npmrc configuration