### PR TITLE
fix: correct package name in changeset file

### DIFF
--- a/.changeset/fix-test-paths.md
+++ b/.changeset/fix-test-paths.md
@@ -1,5 +1,5 @@
 ---
-'@hugsylabs/compiler': patch
+'@hugsylabs/hugsy-compiler': patch
 '@hugsylabs/hugsy': patch
 ---
 


### PR DESCRIPTION
The package name should be @hugsylabs/hugsy-compiler not @hugsylabs/compiler