### PR TITLE
fix: remove deprecated husky v8 script references

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,5 +1,4 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
 
 # Get the commit message
 commit_regex='^(feat|fix|docs|style|refactor|test|chore|perf|build|ci|revert)(\(.+\))?: .{1,100}$'

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
 
 echo "🔒 Checking lockfile..."
 pnpm install --frozen-lockfile || (echo "❌ Lockfile is out of date. Run 'pnpm install' to update it." && exit 1)

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,4 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
 
 echo "🚀 Running pre-push checks..."
 


### PR DESCRIPTION
Remove the deprecated . "./_/husky.sh" lines from all husky hooks These lines are no longer needed in Husky v9 and cause deprecation warnings