### PR TITLE
feat: improve install command UX for existing settings

### DIFF
--- a/.changeset/improve-install-ux.md
+++ b/.changeset/improve-install-ux.md
@@ -1,0 +1,10 @@
+---
+'@hugsylabs/hugsy': patch
+---
+
+Improve install command UX for existing settings
+
+- Change error message to warning when .claude/settings.json exists
+- Add interactive prompt asking user if they want to overwrite
+- Preserve --force flag for non-interactive overwrite
+- Better user experience with clear choices

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,7 +12,7 @@ export default [
       parserOptions: {
         ecmaVersion: 'latest',
         sourceType: 'module',
-        project: ['./tsconfig.json', './packages/*/tsconfig.json'],
+        project: './tsconfig.eslint.json',
         tsconfigRootDir: import.meta.dirname,
       },
       globals: {

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+  "exclude": ["node_modules", "dist", "build", "coverage"]
+}


### PR DESCRIPTION
## Description

Improve user experience when running `hugsy install` with existing `.claude/settings.json` file.

## Changes

### 🎯 Core Improvement
- Changed error to warning when `.claude/settings.json` already exists
- Added interactive prompt asking users if they want to overwrite existing settings
- Smart TTY detection - skips prompt in CI/non-interactive environments
- Preserved `--force` flag for non-interactive overwrite

### 🔧 Additional Fixes
- Added `tsconfig.eslint.json` for proper ESLint TypeScript support
- Fixed all ESLint errors in test files
- Updated test suite to handle new interactive flow

## Motivation

Previously, when users ran `hugsy install` with an existing settings file, they would get an error and have to either:
1. Manually delete the file
2. Use the `--force` flag

This was not user-friendly. Now they get a clear prompt with a choice.

## Testing

- ✅ All 168 tests pass
- ✅ ESLint checks pass
- ✅ Build successful
- ✅ Pre-commit and pre-push hooks pass

## Screenshots

### Before
```
❌ Project already has .claude/settings.json
ℹ️ Use --force to overwrite
```

### After
```
⚠️ Project already has .claude/settings.json
? Do you want to overwrite the existing settings? (y/N)
```

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules